### PR TITLE
candlestick creation rewrite

### DIFF
--- a/tests/genCandleAlgo.py
+++ b/tests/genCandleAlgo.py
@@ -1,0 +1,18 @@
+references = [1, 3, 5, 15, 30, 60, 120, 240, 360, 720, 1440, 4320, 10080]
+
+minutes = 15
+
+for i, j in enumerate(references):
+  if j == minutes:
+    for k in range(i-1, -1, -1):
+      l = minutes / references[k]
+      if l.is_integer():
+        index = k
+        break
+
+print(f"{int(minutes/references[index])} {references[index]} minute candles.")
+
+test = ["a", "b", "c", "d"]
+for i in range(20):
+  if test[i]:
+    print(test[i])

--- a/trade/api/api.py
+++ b/trade/api/api.py
@@ -36,7 +36,7 @@ def createAsset(asset):
 
   db.session.add(newAsset)
 
-def fifteenSecondUpdate():
+def fifteenSecondTasks():
   """
   Used for grabbing necessary price information and updates every 15 seconds.
   Information crucial for making one minute candles.
@@ -63,7 +63,7 @@ def fifteenSecondUpdate():
   db.session.commit()
   app.logger.info("Primary asset data updated.")
 
-def oneMinuteUpdate():
+def oneMinuteTasks():
   """
   Used for updated less time sensitive data then the fifteenSecond() call.
   """
@@ -91,6 +91,18 @@ def oneMinuteUpdate():
 
     dbAsset.buyOrders = pickle.dumps(buyOrders)
     dbAsset.sellOrders = pickle.dumps(sellOrders)
+
+    historicBuyOrders = pickle.loads(dbAsset.sellHistoricOrders)
+    historicSellOrders = pickle.loads(dbAsset.buyHistoricOrders)
+
+    # Adding top current top orders to list of all top orders
+    if len(buy) > 0:
+      historicBuyOrders.append([datetime.utcnow(), buy[0]["amount"], buy[0]["pricePerUnit"], buy[0]["orders"]])
+    if len(sell) > 0:
+      historicSellOrders.append([datetime.utcnow(), sell[0]["amount"], sell[0]["pricePerUnit"], sell[0]["orders"]])
+
+    dbAsset.historicBuyOrders = historicBuyOrders
+    dbAsset.historicSellOrders = historicSellOrders
 
   db.session.commit()
   app.logger.info("Secondary asset data updated.")

--- a/trade/main/routes.py
+++ b/trade/main/routes.py
@@ -20,7 +20,6 @@ def search():
   if request.method == "POST":
     query = request.form["query"]
     query = query.replace(" ", "_")
-    print(query)
     asset = Asset.query.filter(Asset.name.ilike(query)).first()
     if asset:
       return redirect(url_for("asset.specific_asset", asset_name=asset.name))

--- a/trade/templates/asset/asset.html
+++ b/trade/templates/asset/asset.html
@@ -48,7 +48,7 @@
         <h5 class="section-header">Latest Orders</h5>
         <div class="row">
           <div class="col-6">
-            <h5 class="section-subheader">Sell Orders</h5>
+            <h5 class="section-subheader">Ask</h5>
             <table class="assets-table alt">
               <tr>
                 <th class="letter-td">Unit Price</th>
@@ -65,7 +65,7 @@
             </table>            
           </div>
           <div class="col-6">
-            <h5 class="section-subheader">Buy Orders</h5>
+            <h5 class="section-subheader">Bid</h5>
             <table class="assets-table alt">
               <tr>
                 <th class="letter-td">Unit Price</th>
@@ -164,6 +164,42 @@
               </div>
             {% else %}
               {{ form.sellTime(class="") }}
+            {% endif %}  
+            </div>
+          </div>
+          <div class="clear"></div>
+          <div class="form-group">
+            <div class="form-label">
+              <p>Purchase Type</p>
+            </div>
+            <div class="form-field">
+              {% if form.purchaseType.errors %}
+              {{ form.purchaseType(class="invalid") }}
+              <div class="invalid-feedback">
+                  {% for error in form.purchaseType.errors %}
+                    <span>{{ error }}</span>
+                  {% endfor %}
+              </div>
+            {% else %}
+              {{ form.purchaseType(class="") }}
+            {% endif %}
+            </div>
+          </div>
+          <div class="clear"></div>
+          <div class="form-group">
+            <div class="form-label">
+              <p>Sell Type</p>
+            </div>
+            <div class="form-field">
+              {% if form.sellType.errors %}
+              {{ form.sellType(class="invalid") }}
+              <div class="invalid-feedback">
+                  {% for error in form.sellType.errors %}
+                    <span>{{ error }}</span>
+                  {% endfor %}
+              </div>
+            {% else %}
+              {{ form.sellType(class="") }}
             {% endif %}  
             </div>
           </div>


### PR DESCRIPTION
Complete rewrite of candlestick creation. Any candlestick larger than one minute now points the next smallest divisible candlestick. E.g. a 5 minute candlestick will point to 5, one minute candlesticks. A 1 week candlestick will point to 7 day candlesticks. This should save time and processing power on especially larger candlesticks in the long run.

*Add purging of old candlestick data after a certain amount of time to prevent mass data accumulation.*