### PR TITLE
fixed accuracy of margins

### DIFF
--- a/trade/api/api.py
+++ b/trade/api/api.py
@@ -99,10 +99,11 @@ def oneMinuteTasks():
     # Adding top current top orders to list of all top orders
     if len(buy) > 0:
       historicBuyOrders.append([datetime.utcnow(), buy[0]["amount"], buy[0]["pricePerUnit"], buy[0]["orders"]])
-      dbAsset.topBuyOrder = buy[0]["pricePerUnit"]
     if len(sell) > 0:
       historicSellOrders.append([datetime.utcnow(), sell[0]["amount"], sell[0]["pricePerUnit"], sell[0]["orders"]])
-      dbAsset.topSellOrder = sell[0]["pricePerUnit"]
+
+    if len(buy) > 0 and buy[0]["pricePerUnit"] != 0:
+      dbAsset.margin = ((1 - (sell[0]["pricePerUnit"] / buy[0]["pricePerUnit"]))*100)
 
     dbAsset.historicBuyOrders = historicBuyOrders
     dbAsset.historicSellOrders = historicSellOrders

--- a/trade/asset/routes.py
+++ b/trade/asset/routes.py
@@ -44,9 +44,9 @@ def filterAssets():
 
   elif mainFilter == "margin":
     if orderBy == "asc":
-      assets = Asset.query.filter(Asset.buyPrice!=0).filter(Asset.name.like(searchText)).order_by(Asset.calcMargin().asc())
+      assets = Asset.query.filter(Asset.buyPrice!=0).filter(Asset.name.like(searchText)).order_by(Asset.margin.asc())
     else:
-      assets = Asset.query.filter(Asset.buyPrice!=0).filter(Asset.name.like(searchText)).order_by(Asset.calcMargin().desc())
+      assets = Asset.query.filter(Asset.buyPrice!=0).filter(Asset.name.like(searchText)).order_by(Asset.margin.desc())
 
   else:
     assets = Asset.query.filter(Asset.name.like(searchText)).order_by(Asset.name.asc())
@@ -69,4 +69,4 @@ def specific_asset(asset_name):
   if form.reset.data and form.validate():
     session.pop("margin")
 
-  return render_template("asset/asset.html", asset=asset, form=form, title=asset.name, pickle=pickle)
+  return render_template("asset/asset.html", asset=asset, form=form, title=asset.prettyName, pickle=pickle)

--- a/trade/config.py
+++ b/trade/config.py
@@ -9,7 +9,7 @@ class Config(object):
 
   # Used for enabling or disabling price and candle updates
   # Used for decreasing required processing power of application
-  UPDATE_CANDLES = False
+  UPDATE_CANDLES = True
 
   with open("trade/API_KEY", "r") as f:
     API_KEY = f.read()

--- a/trade/models.py
+++ b/trade/models.py
@@ -101,7 +101,6 @@ class Asset(db.Model):
   sellVolume = db.Column(db.Integer(), nullable=False)
   sellMovingWeek = db.Column(db.Integer(), nullable=False)
   sellOrderAmount = db.Column(db.Integer(), nullable=False)
-  topSellOrder = db.Column(db.Integer())
   sellOrders = db.Column(db.PickleType(), nullable=False, default=pickle.dumps([]))
   sellHistoricOrders = db.Column(db.PickleType(), nullable=False, default=pickle.dumps([]))
 
@@ -110,9 +109,10 @@ class Asset(db.Model):
   buyVolume = db.Column(db.Integer(), nullable=False)
   buyMovingWeek = db.Column(db.Integer(), nullable=False)
   buyOrderAmount = db.Column(db.Integer(), nullable=False)
-  topBuyOrder = db.Column(db.Integer())
   buyOrders = db.Column(db.PickleType(), nullable=False, default=pickle.dumps([]))
   buyHistoricOrders = db.Column(db.PickleType(), nullable=False, default=pickle.dumps([]))
+
+  margin = db.Column(db.Float(precision=2))
 
   ohlc = db.relationship("Candle", backref="asset", lazy=True)
 
@@ -127,18 +127,6 @@ class Asset(db.Model):
     buyPrices = pickle.loads(self.buyPrices)
     buyPrices.append([datetime.utcnow(), self.buyPrice])
     self.buyPrices = pickle.dumps(buyPrices)
-
-  @property
-  def printMargin(self):
-    margin = 0
-    if self.topBuyOrder != None:
-      margin = (1 - (self.topSellOrder / self.topBuyOrder))*100
-
-    return round(margin, 2)
-
-  @classmethod
-  def calcMargin(self):
-    pass
 
   @property
   def volumeAbr(self):

--- a/trade/templates/asset/assets.html
+++ b/trade/templates/asset/assets.html
@@ -60,7 +60,7 @@
           <a href="#"><td class="letter-td">{{ asset.name.title().replace("_", " ") }}</td></a>
           <td class="number-td">{{ round(asset.sellPrice, 2) }}</td>
           <td class="number-td">{{ round(asset.buyPrice, 2) }}</td>
-          <td class="number-td">{{ asset.printMargin }}%</td>
+          <td class="number-td">{{ round(asset.margin, 2) }}%</td>
           <td class="number-td">{{ asset.volumeAbr }}</td>
           {% if asset.movingValue > 0 %}
             <td class="number-td green">{{ asset.movingValue }}%</td>


### PR DESCRIPTION
Margins were not being based off the top order but the supplied price of the item from the hypixel API (weighted average of the top 2% of orders). These margins weren't accurate for bazaar flipping and resell.